### PR TITLE
bugfix: avoid flickering of the full new frame before the transition starts

### DIFF
--- a/app/src/main/java/com/hannesdorfmann/conductor_shared_element_transition/DetailsToListChangeHandler.kt
+++ b/app/src/main/java/com/hannesdorfmann/conductor_shared_element_transition/DetailsToListChangeHandler.kt
@@ -44,16 +44,7 @@ class DetailsToListChangeHandler(private var position: Int) : ControllerChangeHa
       this.listView = to as RecyclerView
       this.container = container
 
-      // Find the index listView add the listView view
-      for (i in 0..container.childCount - 1) {
-        if (container.getChildAt(i) == from) {
-          // Add the list view in the hierarchy after the details view,
-          // so that both are in the container, but the details view is in the front and therefore
-          // the list view is not visible because hidden behind details view
-          container.addView(listView, i)
-          break
-        }
-      }
+      container.addView(listView)
 
     } else {
       // Not sure if this can ever be the case

--- a/app/src/main/java/com/hannesdorfmann/conductor_shared_element_transition/DetailsToListChangeHandler.kt
+++ b/app/src/main/java/com/hannesdorfmann/conductor_shared_element_transition/DetailsToListChangeHandler.kt
@@ -44,6 +44,9 @@ class DetailsToListChangeHandler(private var position: Int) : ControllerChangeHa
       this.listView = to as RecyclerView
       this.container = container
 
+      // Adding the listView to the view hierarchy, to start the view life cycle
+      // and waiting for the listView to lay out it's children
+      // Note: The installed onPreDrawListener (see ListAdapter.kt) will prevent the view from showing up for one frame
       container.addView(listView)
 
     } else {
@@ -84,8 +87,9 @@ class DetailsToListChangeHandler(private var position: Int) : ControllerChangeHa
       }
     })
 
-    //viewHolder.itemView.visibility = View.GONE
+    // The target view of the shared element is laid out, so we are now ready to start the transition
     listView?.removeView(viewHolder.itemView)
+
     TransitionManager.beginDelayedTransition(container, t)
     container?.removeView(detailsView)
     listView?.addView(viewHolder.itemView)

--- a/app/src/main/java/com/hannesdorfmann/conductor_shared_element_transition/ListAdapter.kt
+++ b/app/src/main/java/com/hannesdorfmann/conductor_shared_element_transition/ListAdapter.kt
@@ -60,7 +60,11 @@ class ListAdapter(val inflater: LayoutInflater, val clickListener: (position: In
     override fun onPreDraw(): Boolean {
       viewHolder.itemView.viewTreeObserver.removeOnPreDrawListener(this)
       viewHolderPredrawedListener?.invoke(position, viewHolder)
-      return true
+
+      // Returning false, so the view is not drawn the first time it is added to the view hierachy
+      // This avoids flickering, because upon adding it to the view hierachy the android framework tries to draw it
+      // Just setting the Visibility to INVISIBLE doesnt' work
+      return false
     }
   }
 }


### PR DESCRIPTION
see issue at: https://github.com/bluelinelabs/Conductor/issues/193
